### PR TITLE
Prelude Updates

### DIFF
--- a/prelude.ktn
+++ b/prelude.ktn
@@ -759,3 +759,44 @@ def zipWith ([a] [b] (a b -> c) -> [c]):
   else:
     as tail bs tail f zipWith
     as head bs head f apply21 prepend
+
+// Range of integers from start to finish generating
+// based on a given next and compare functions
+def rangeFor (Int Int (Int -> Int) (Int Int -> Bool) -> [Int]):
+  -> { start end next cmp }
+  if start end cmp apply21 then:
+    []
+  else:
+    start next apply11 end next cmp rangeFor start prepend
+
+// Non-inclusive range
+def rangeUntil (Int Int -> [Int]):
+  -> { start end }
+  if start end < then:
+    start end { ++ } { >= } rangeFor
+  else:
+    start end { -- } { <= } rangeFor
+
+// Inclusive range
+def rangeTo (Int Int -> [Int]):
+  -> { start end }
+  if start end < then:
+    start end { ++ } { > } rangeFor
+  else:
+    start end { -- } { < } rangeFor
+
+// Inclusive range (shorthand)
+def .. (Int Int -> [Int]) { rangeTo }
+
+// Non-inclusive range (shorthand)
+def ... (Int Int -> [Int]) { rangeUntil }
+
+// Left-leaning vector fold starting from first element
+def foldl1 ([a] (a a -> a) -> a):
+  -> { xs fn }
+  xs tail xs head fn fold
+
+// Right-leaning vector fold starting from last element
+def foldr1 ([a] (a a -> a) -> a):
+  -> { xs fn }
+  xs init xs last fn foldr


### PR DESCRIPTION
Fixes splitAt to return output in expected order ([1,2,3,4,5] 2 splitAt === [1,2] [3,4,5]) and adds various integer range generation functions to prelude.
