### PR TITLE
adding TextMate / SublimeText syntax highlights

### DIFF
--- a/syntax/Kitten.JSON-tmLanguage
+++ b/syntax/Kitten.JSON-tmLanguage
@@ -41,7 +41,7 @@
           "1": { "name": "keyword.control.kitten" },
           "2": { "name": "entity.name.function.kitten" }
       },
-      "end": "\\)",
+      "end": "\\)\\s*[:{]",
       "patterns": [
         { "include": "#typesignature" }
       ]

--- a/syntax/Kitten.tmLanguage
+++ b/syntax/Kitten.tmLanguage
@@ -92,7 +92,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>\)</string>
+			<string>\)\s*[:{]</string>
 			<key>name</key>
 			<string>meta.functiondef.kitten</string>
 			<key>patterns</key>


### PR DESCRIPTION
For issue #57.

The `Kitten.JSON-tmLanguage` file is used to generate the `Kitten.tmLanguage` file, which is what the editor reads to provide syntax highlighting. I've included both here for convenience.

Here's what it looks like with the default theme in Sublime Text 2:
![screen shot](https://f.cloud.github.com/assets/82855/884180/8e479a2e-f9ab-11e2-992b-cf40206066cf.png)
