### PR TITLE
Don't ghc -prof on the Kitten executable

### DIFF
--- a/kitten.cabal
+++ b/kitten.cabal
@@ -110,7 +110,7 @@ executable kitten
     -Wall
 
   if flag(prof)
-    ghc-options: -prof -auto-all
+    ghc-options: -auto-all
 
   build-depends:
     kitten,


### PR DESCRIPTION
Cabal emits a warning:

> Warning: 'ghc-options: -prof' is not necessary and will
> lead to problems when used on a library. Use the configure
> flag --enable-library-profiling and/or
> --enable-executable-profiling.
