### PR TITLE
Better location information for definition bodies

### DIFF
--- a/lib/Kitten/Parse.hs
+++ b/lib/Kitten/Parse.hs
@@ -65,10 +65,10 @@ def = (<?> "definition") . locate $ do
   void (match Token.Def)
   name <- functionName <?> "definition name"
   anno <- optionMaybe signature
-  body <- block <?> "definition body"
+  body <- locate (Function <$> block) <?> "definition body"
   return $ \loc -> Def
     { defName = name
-    , defTerm = Function body loc
+    , defTerm = body
     , defAnno = anno
     , defLocation = loc
     }


### PR DESCRIPTION
Locations of the body are now on the '{' or ':' of a
definition, instead of on the 'def' of a definition.
