### PR TITLE
Use NameGen for name generation in type inferer

### DIFF
--- a/lib/Kitten/Infer.hs
+++ b/lib/Kitten/Infer.hs
@@ -47,14 +47,22 @@ typeFragment
   -> [Value]
   -> Fragment Resolved
   -> Fragment Resolved
-  -> Either [ErrorGroup] (Type Scalar)
-typeFragment config stack prelude fragment
-  = fst . runInference config emptyEnv
-  $ inferFragment prelude fragment
-    { fragmentTerms
-      = V.map (`Push` UnknownLocation) (V.reverse (V.fromList stack))
-      <> fragmentTerms fragment
-    }
+  -> NameGen
+  -> Either [ErrorGroup] (NameGen, Type Scalar)
+typeFragment config stack prelude fragment nameGen
+  = case run of
+    (Left err, _) -> Left err
+    (Right type_, env') -> Right (envNameGen env', type_)
+  where
+  run :: (Either [ErrorGroup] (Type Scalar), Env)
+  run = runInference config env
+    $ inferFragment prelude fragment
+      { fragmentTerms
+        = V.map (`Push` UnknownLocation) (V.reverse (V.fromList stack))
+        <> fragmentTerms fragment
+      }
+  env :: Env
+  env = emptyEnv { envNameGen = nameGen }
 
 inferFragment
   :: Fragment Resolved

--- a/lib/Kitten/Infer/Monad.hs
+++ b/lib/Kitten/Infer/Monad.hs
@@ -54,7 +54,7 @@ data Env = Env
   , envEffects :: !(NameMap (Type Effect))
   , envLocals :: [Type Scalar]
   , envLocation :: !Location
-  , envNext  :: !Name
+  , envNameGen :: !NameGen
   , envRows :: !(NameMap (Type Row))
   , envScalars :: !(NameMap (Type Scalar))
   , envTypeDefs :: !(Map Text Scheme)
@@ -87,7 +87,7 @@ emptyEnv = Env
   , envEffects = N.empty
   , envLocals = []
   , envLocation = UnknownLocation
-  , envNext = Name 0
+  , envNameGen = mkNameGen
   , envRows = N.empty
   , envScalars = N.empty
   , envTypeDefs = M.empty
@@ -124,8 +124,8 @@ asksConfig = Inferred . lift . asks
 
 freshName :: Env -> (Name, Env)
 freshName env
-  = let current = envNext env
-  in (current, env { envNext = succ current })
+  = let (name, gen') = genName (envNameGen env)
+  in (name, env { envNameGen = gen' })
 
 freshVar :: Location -> Env -> (Type a, Env)
 freshVar loc env

--- a/lib/Kitten/Name.hs
+++ b/lib/Kitten/Name.hs
@@ -3,6 +3,10 @@
 
 module Kitten.Name
   ( Name(..)
+  , NameGen
+  , genName
+  , mkNameGen
+  , mkNameGenFrom
   , nameIndex
   ) where
 
@@ -20,6 +24,17 @@ instance Show Name where
 
 instance ToText Name where
   toText (Name name) = "_" <> showText name
+
+newtype NameGen = NameGen Name
+
+genName :: NameGen -> (Name, NameGen)
+genName (NameGen name) = (name, NameGen (succ name))
+
+mkNameGen :: NameGen
+mkNameGen = mkNameGenFrom (Name 0)
+
+mkNameGenFrom :: Name -> NameGen
+mkNameGenFrom = NameGen
 
 nameIndex :: Name -> Int
 nameIndex (Name index) = index


### PR DESCRIPTION
This prevents type variables from being duplicated in
subsequent executions of the type inference engine.

(At the moment, every line given to the REPL will reinfer
the prelude.  In another patch, that will not be the case,
and the prelude will be typechecked once.)
