### PR TITLE
Fix order of REPL stack types given to inference

### DIFF
--- a/lib/Kitten/Compile.hs
+++ b/lib/Kitten/Compile.hs
@@ -70,7 +70,7 @@ compile Compile.Config{..} nameGen = liftM (mapLeft sort) . runEitherT $ do
   when dumpScoped . lift $ hPrint stderr scoped
 
   (nameGen', typed, type_) <- hoistEither
-    $ typeFragment inferConfig stack prelude scoped nameGen
+    $ typeFragment inferConfig stackTypes prelude scoped nameGen
 
   return (nameGen', typed, type_)
 

--- a/lib/Kitten/Compile/Config.hs
+++ b/lib/Kitten/Compile/Config.hs
@@ -3,6 +3,7 @@ module Kitten.Compile.Config
   ) where
 
 import Data.Text (Text)
+import Data.Vector (Vector)
 
 import Kitten.Fragment
 import Kitten.Type
@@ -19,5 +20,5 @@ data Config = Config
   , name :: String
   , prelude :: !(Fragment Typed)
   , source :: !Text
-  , stack :: [Type Scalar]
+  , stackTypes :: Vector (Type Scalar)
   }

--- a/lib/Kitten/Infer.hs
+++ b/lib/Kitten/Infer.hs
@@ -48,7 +48,7 @@ import qualified Kitten.Util.Vector as V
 
 typeFragment
   :: Config
-  -> [Type Scalar]
+  -> Vector (Type Scalar)
   -> Fragment Typed
   -> Fragment Resolved
   -> NameGen
@@ -67,7 +67,7 @@ typeFragment config stackTypes prelude fragment nameGen
 inferFragment
   :: Fragment Typed
   -> Fragment Resolved
-  -> [Type Scalar]
+  -> Vector (Type Scalar)
   -> Inferred (Fragment Typed, Type Scalar)
 inferFragment prelude fragment stackTypes = mdo
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -56,7 +56,7 @@ main = do
       , Compile.name = filename
       , Compile.prelude = prelude
       , Compile.source = program
-      , Compile.stack = []
+      , Compile.stackTypes = V.empty
       }
 
   preludes <- locateImport

--- a/src/Repl.hs
+++ b/src/Repl.hs
@@ -131,7 +131,7 @@ compileConfig = do
       , fragmentTypeDefs = replTypeDefs
       }
     , Compile.source = ""
-    , Compile.stack = []
+    , Compile.stackTypes = V.empty
     }
 
 replCompile
@@ -166,7 +166,7 @@ eval line = do
     lift . modify $ \env -> env { replNameGen = nameGen' }
     replCompile $ \config -> config
       { Compile.source = line
-      , Compile.stack = stackTypes
+      , Compile.stackTypes = V.fromList (reverse stackTypes)
       }
 
   whenJust mCompiled $ \(compiled, _type) -> do


### PR DESCRIPTION
The REPL stack is right-to-left, but type inference expected
stack types left-to-right.  A `[Type Scalar]` named 'stack'
or 'stackTypes' would be understood as right-to-left, so
this change makes the type a `Vector (Type Scalar)` (meaning
left-to-right) instead.
