### PR TITLE
Pair display

### DIFF
--- a/lib/Kitten/Interpret/Monad.hs
+++ b/lib/Kitten/Interpret/Monad.hs
@@ -37,6 +37,7 @@ import Kitten.Name
 import Kitten.Type (Type((:&), (:?), (:|)))
 import Kitten.Typed (Typed, TypedDef)
 import Kitten.Util.Text (ToText(..), showText)
+import Kitten.Util.Applicative ((.&&.))
 
 import qualified Kitten.Type as Type
 import qualified Kitten.Typed as Typed
@@ -86,7 +87,7 @@ instance ToText InterpreterValue where
     Pair a b ->
       let
         pairText = T.concat [T.pack "(", toText a, T.pack ", ", toText b, T.pack ")"]
-        stripped = T.filter (\x -> x /= '(' && x /= ')') pairText
+        stripped = T.filter ((/= '(') .&&. (/= ')')) pairText
       in T.concat [T.pack "(", stripped, T.pack ")"]
     Unit -> "()"
     Vector v@(V.toList -> (Char _ : _)) -> showText (stringFromChars v)


### PR DESCRIPTION
Displays pairs and nested pairs as `(1, 2, 3, 4, 5, ...)` instead of `1 2 pair 3 pair 4 pair 5 pair ...` in the interpreter repl.
