### PR TITLE
Remove unused 'Kitten.Type.Test' constructor

### DIFF
--- a/lib/Kitten/Infer/Locations.hs
+++ b/lib/Kitten/Infer/Locations.hs
@@ -28,7 +28,6 @@ locations type_ = case type_ of
   Handle loc -> yield loc
   Int loc -> yield loc
   Named _ loc -> yield loc
-  Test -> []
   Unit loc -> yield loc
   Var _ loc -> yield loc
   Vector a loc -> yield loc ++ locations a

--- a/lib/Kitten/Infer/Scheme.hs
+++ b/lib/Kitten/Infer/Scheme.hs
@@ -102,7 +102,6 @@ class Free a where
 instance Free Effect where
   free type_ = case type_ of
     a :+ b -> free a <> free b
-    Test -> mempty
     NoEffect _ -> mempty
     IOEffect _ -> mempty
     Var name _ -> ([], [], [name])
@@ -111,7 +110,6 @@ instance Free Row where
   free type_ = case type_ of
     a :. b -> free a <> free b
     Empty{} -> mempty
-    Test{} -> mempty
     Var name _ -> ([name], [], [])
 
 instance Free Scalar where
@@ -126,7 +124,6 @@ instance Free Scalar where
     Handle{} -> mempty
     Int{} -> mempty
     Named{} -> mempty
-    Test{} -> mempty
     Var name _ -> ([], [name], [])
     Unit{} -> mempty
     Vector a _ -> free a
@@ -160,7 +157,6 @@ instance Occurrences Effect where
     a :+ b -> occurrences name env a + occurrences name env b
     NoEffect _ -> 0
     IOEffect _ -> 0
-    Test -> 0
     Var typeName@(TypeName name') _ -> case retrieve env typeName of
       Left{} -> if name == name' then 1 else 0  -- See Note [Var Kinds].
       Right type' -> occurrences name env type'
@@ -169,7 +165,6 @@ instance Occurrences Row where
   occurrences name env type_ = case type_ of
     a :. b -> occurrences name env a + occurrences name env b
     Empty{} -> 0
-    Test -> 0
     Var typeName@(TypeName name') _ -> case retrieve env typeName of
       Left{} -> if name == name' then 1 else 0  -- See Note [Var Kinds].
       Right type' -> occurrences name env type'
@@ -188,7 +183,6 @@ instance Occurrences Scalar where
     Handle{} -> 0
     Int{} -> 0
     Named{} -> 0
-    Test{} -> 0
     Var typeName@(TypeName name') _ -> case retrieve env typeName of
       Left{} -> if name == name' then 1 else 0  -- See Note [Var Kinds].
       Right type' -> occurrences name env type'
@@ -233,7 +227,6 @@ instance Substitute Effect where
     a :+ b -> sub env a +: sub env b
     NoEffect _ -> type_
     IOEffect _ -> type_
-    Test{} -> type_
     Var name _
       | Right type' <- retrieve env name
       -> sub env type'
@@ -244,7 +237,6 @@ instance Substitute Row where
   sub env type_ = case type_ of
     a :. b -> sub env a :. sub env b
     Empty{} -> type_
-    Test{} -> type_
     Var name _
       | Right type' <- retrieve env name
       -> sub env type'
@@ -267,7 +259,6 @@ instance Substitute Scalar where
     Int{} -> type_
     Handle{} -> type_
     Named{} -> type_
-    Test -> type_
     Var name _
       | Right type' <- retrieve env name
       -> sub env type'

--- a/lib/Kitten/Type.hs
+++ b/lib/Kitten/Type.hs
@@ -50,7 +50,6 @@ data Type (a :: Kind) where
   Handle :: !Location -> Type Scalar
   Int :: !Location -> Type Scalar
   Named :: !Text -> !Location -> Type Scalar
-  Test :: Type a
   Unit :: !Location -> Type Scalar
   Var :: !(TypeName a) -> !Location -> Type a
   Vector :: !(Type Scalar) -> !Location -> Type Scalar
@@ -60,9 +59,6 @@ data Type (a :: Kind) where
   IOEffect :: !Location -> Type Effect
 
 instance Eq (Type a) where
-  Test == _ = True
-  _ == Test = True
-
   (a :& b) == (c :& d) = (a, b) == (c, d)
   (a :. b) == (c :. d) = (a, b) == (c, d)
   (:?) a == (:?) b = a == b
@@ -109,7 +105,6 @@ instance ToText (Type Scalar) where
     Handle{} -> "Handle"
     Int{} -> "Int"
     Named name _ -> name
-    Test{} -> ""
     Var (TypeName (Name index)) _ -> "t" <> showText index
     Unit{} -> "()"
     Vector t _ -> T.concat ["[", toText t, "]"]
@@ -118,13 +113,11 @@ instance ToText (Type Row) where
   toText = \case
     t1 :. t2 -> T.unwords [toText t1, toText t2]
     Empty{} -> "<empty>"
-    Test{} -> ""
     Var (TypeName (Name index)) _ -> "r" <> showText index
 
 instance ToText (Type Effect) where
   toText = \case
     t1 :+ t2 -> T.concat ["(", toText t1, " + ", toText t2, ")"]
-    Test{} -> ""
     Var (TypeName (Name index)) _ -> "e" <> showText index
     NoEffect{} -> "()"
     IOEffect{} -> "IO"

--- a/lib/Kitten/Type/Tidy.hs
+++ b/lib/Kitten/Type/Tidy.hs
@@ -118,7 +118,6 @@ tidyScalarType type_ = case type_ of
   Handle{} -> pure type_
   Int{} -> pure type_
   Named{} -> pure type_
-  Test{} -> pure type_
   Var name loc -> Var <$> tidyScalar name <*> pure loc
   Unit{} -> pure type_
   Vector t loc -> Vector <$> tidyScalarType t <*> pure loc
@@ -128,7 +127,6 @@ tidyRowType type_ = case type_ of
   t1 :. t2 -> (:.) <$> tidyRowType t1 <*> tidyScalarType t2
   Empty{} -> pure type_
   Var name loc -> Var <$> tidyRow name <*> pure loc
-  Test{} -> pure type_
 
 tidyEffectType :: Type Effect -> Tidy (Type Effect)
 tidyEffectType type_ = case type_ of
@@ -136,4 +134,3 @@ tidyEffectType type_ = case type_ of
   Var name loc -> Var <$> tidyEffect name <*> pure loc
   NoEffect{} -> pure type_
   IOEffect{} -> pure type_
-  Test{} -> pure type_


### PR DESCRIPTION
'Test' was unused; all references were merely pattern matching and performing some default.
