### PR TITLE
Prefix row variables with '.' in ToText

### DIFF
--- a/lib/Kitten/Type.hs
+++ b/lib/Kitten/Type.hs
@@ -113,7 +113,7 @@ instance ToText (Type Row) where
   toText = \case
     t1 :. t2 -> T.unwords [toText t1, toText t2]
     Empty{} -> "<empty>"
-    Var (TypeName (Name index)) _ -> "r" <> showText index
+    Var (TypeName (Name index)) _ -> ".r" <> showText index
 
 instance ToText (Type Effect) where
   toText = \case


### PR DESCRIPTION
Before:

```
(r1434 [Bool] Bool (r1433 Bool Bool -> r1433 Bool + ()) -> r1434 Bool + ())
```

After:

```
(.r1434 [Bool] Bool (.r1433 Bool Bool -> .r1433 Bool + ()) -> .r1434 Bool + ())
```

Fixes #106.
