### PR TITLE
Give unification an explicit expected/actual distinction.

### DIFF
--- a/lib/Kitten/Infer.hs
+++ b/lib/Kitten/Infer.hs
@@ -84,10 +84,10 @@ typeFragment fragment = do
       let TyFunction consumption _ _ = fragmentType
       bottom <- freshVarM
       enforce <- asksConfig configEnforceBottom
-      when enforce $ bottom === TyEmpty (Origin HiNone topLevel)
+      when enforce $ bottom `shouldBe` TyEmpty (Origin HiNone topLevel)
       stackTypes <- asksConfig configStackTypes
       let stackType = F.foldl (:.) bottom stackTypes
-      stackType === consumption
+      consumption `shouldBe` stackType
 
     let
       typedFragment = fragment
@@ -127,7 +127,7 @@ instanceCheck :: TypeScheme -> TypeScheme -> ErrorGroup -> K ()
 instanceCheck inferredScheme declaredScheme errorGroup = do
   inferredType <- instantiateM inferredScheme
   (stackConsts, scalarConsts, declaredType) <- skolemize declaredScheme
-  inferredType === declaredType
+  inferredType `shouldBe` declaredType
   let
     (escapedStacks, escapedScalars) = free inferredScheme <> free declaredScheme
     badStacks = filter (`elem` escapedStacks) stackConsts
@@ -448,7 +448,7 @@ fromConstant type_ = do
   a <- freshVarM
   r <- freshVarM
   origin <- getsProgram inferenceOrigin
-  type_ === (r --> r :. a) origin
+  type_ `shouldBe` (r --> r :. a) origin
   return a
 
 binary :: Type Scalar -> Origin -> K (Type Scalar)
@@ -515,7 +515,7 @@ unifyEach xs = go 0
     else if i == V.length xs - 1
       then return (xs V.! i)
       else do
-        xs V.! i === xs V.! (i + 1)
+        xs V.! i `shouldBe` xs V.! (i + 1)
         go (i + 1)
 
 inferCompose
@@ -523,5 +523,5 @@ inferCompose
   -> Type Stack -> Type Stack
   -> K (Type Scalar)
 inferCompose in1 out1 in2 out2 = do
-  out1 === in2
+  out1 `shouldBe` in2
   TyFunction in1 out2 <$> getsProgram inferenceOrigin

--- a/lib/Kitten/Infer/Locations.hs
+++ b/lib/Kitten/Infer/Locations.hs
@@ -1,29 +1,36 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 
 module Kitten.Infer.Locations
-  ( diagnosticLocations
+  ( DiagnosticLocations(..)
   ) where
 
 import Data.Text (Text)
 
-import Kitten.Util.Text (ToText(..))
 import Kitten.Types
+import Kitten.Util.Text (ToText(..))
 
 -- | A list of locations and associated types, suitable for
 -- presenting to the end user for diagnostic purposes (e.g.
 -- type errors).
-diagnosticLocations
-  :: (ToText (Type a)) => Type a -> [(Origin, Text)]
-diagnosticLocations type_ = case type_ of
+class DiagnosticLocations a where
+  diagnosticLocations :: Type a -> [(Origin, Text)]
+
+instance DiagnosticLocations Scalar where
+  diagnosticLocations = scalarLocations
+
+instance DiagnosticLocations Stack where
+  diagnosticLocations = stackLocations
+
+scalarLocations :: Type Scalar -> [(Origin, Text)]
+scalarLocations type_ = case type_ of
   a :& b -> locations a ++ locations b
-  a :. b -> locations a ++ locations b
   (:?) a -> locations a
   a :| b -> locations a ++ locations b
   TyConst _ loc -> yield loc
   TyCtor _ loc -> yield loc
-  TyEmpty loc -> yield loc
-  TyFunction r s loc -> yield loc ++ locations r ++ locations s
+  TyFunction r s loc -> yield loc ++ stackLocations r ++ stackLocations s
   TyQuantified _ loc -> yield loc
   TyVar _ loc -> yield loc
   TyVector a loc -> yield loc ++ locationsIfUnhinted loc a
@@ -31,11 +38,14 @@ diagnosticLocations type_ = case type_ of
   where
   yield origin = [(origin, toText type_)]
 
-  locations
-    :: (ToText (Type a)) => Type a -> [(Origin, Text)]
-  locations = diagnosticLocations
+  locations :: Type Scalar -> [(Origin, Text)]
+  locations = scalarLocations
 
-  locationsIfUnhinted
-    :: (ToText (Type a)) => Origin -> Type a -> [(Origin, Text)]
+  locationsIfUnhinted :: Origin -> Type Scalar -> [(Origin, Text)]
   locationsIfUnhinted (Origin HiNone _) = locations
   locationsIfUnhinted (Origin _ _) = const []
+
+stackLocations :: Type Stack -> [(Origin, Text)]
+stackLocations type_ = case type_ of
+  a :. b -> stackLocations a ++ scalarLocations b
+  _ -> []

--- a/lib/Kitten/Infer/Unify.hs
+++ b/lib/Kitten/Infer/Unify.hs
@@ -7,12 +7,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Kitten.Infer.Unify
-  ( (===)
+  ( shouldBe
   , unifyM
   , unifyM_
   , unifyVar
   ) where
 
+-- import Control.Applicative
 import Control.Monad
 import Data.Function
 import Data.Text (Text)
@@ -26,6 +27,7 @@ import Kitten.Infer.Scheme
 import Kitten.Location
 import Kitten.Type.Tidy
 import Kitten.Types
+import Kitten.Util.Either
 import Kitten.Util.FailWriter
 import Kitten.Util.Maybe
 import Kitten.Util.Text (ToText(..))
@@ -37,7 +39,8 @@ unify
   -> Type a
   -> Program
   -> Either [ErrorGroup] Program
-unify a b program = (unification `on` simplify program) a b program
+unify have want program
+  = (unification `on` simplify program) have want program
 
 class Unification a where
   unification
@@ -47,60 +50,85 @@ class Unification a where
     -> Either [ErrorGroup] Program
 
 instance Unification Stack where
-  unification type1 type2 program = case (type1, type2) of
-    _ | type1 == type2 -> Right program
-
-    (a :. b, c :. d) -> unify b d program >>= unify a c
-
-    (TyVar var (Origin hint _), type_) -> unifyVar var (type_ `addHint` hint) program
-    (_, TyVar{}) -> commutative
-
-    _ -> Left $ unificationError Nothing
-      (originLocation $ inferenceOrigin program) type1 type2
-
-    where commutative = unification type2 type1 program
+  unification have want program = case (have, want) of
+    _ | have == want -> Right program
+    (a :. b, c :. d) -> withContext' $ unify b d program >>= unify a c
+    (TyVar var (Origin hint _), type_)
+      -> withContext' $ unifyVar var (type_ `addHint` hint) program
+    (type_, TyVar var (Origin hint _))
+      -> withContext' $ unifyVar var (type_ `addHint` hint) program
+    _ -> Left $ unificationError Nothing loc have want
+    where
+    withContext' = withContext have want loc
+    loc = originLocation $ inferenceOrigin program
 
 instance Unification Scalar where
-  unification type1 type2 program = case (type1, type2) of
-    _ | type1 == type2 -> Right program
-    (a :& b, c :& d) -> unify b d program >>= unify a c
-    ((:?) a, (:?) b) -> unify a b program
-    (a :| b, c :| d) -> unify b d program >>= unify a c
-    (TyFunction a b _, TyFunction c d _) -> unify b d program >>= unify a c
-    (TyVector a _, TyVector b _) -> unify a b program
-    (TyVar var (Origin hint _), type_) -> unifyVar var (type_ `addHint` hint) program
-    (_, TyVar{}) -> commutative
-    (TyQuantified scheme loc, _) -> let
-      (type', program') = instantiate loc scheme program
-      in unify type' type2 program'
-    (_, TyQuantified{}) -> commutative
+  unification have want program = case (have, want) of
+    _ | have == want -> Right program
+    (a :& b, c :& d) -> withContext' $ unify b d program >>= unify a c
+    ((:?) a, (:?) b) -> withContext' $ unify a b program
+    (a :| b, c :| d) -> withContext' $ unify b d program >>= unify a c
+    (TyFunction a b _, TyFunction c d _)
+      -> withContext' $ unify b d program >>= unify a c
+    (TyVector a _, TyVector b _) -> withContext' $ unify a b program
+    (TyVar var (Origin hint _), type_)
+      -> withContext' $ unifyVar var (type_ `addHint` hint) program
+    (type_, TyVar var (Origin hint _))
+      -> withContext' $ unifyVar var (type_ `addHint` hint) program
+    (TyQuantified scheme loc', type_) -> withContext' $ let
+      (type', program') = instantiate loc' scheme program
+      in unify type' type_ program'
+    (type_, TyQuantified scheme loc') -> withContext' $ let
+      (type', program') = instantiate loc' scheme program
+      in unify type' type_ program'
+    _ -> Left $ unificationError Nothing loc have want
+    where
+    withContext' = withContext have want loc
+    loc = originLocation $ inferenceOrigin program
 
-    _ -> Left $ unificationError Nothing
-      (originLocation $ inferenceOrigin program) type1 type2
+withContext
+  :: forall (a :: Kind) b
+  . (DiagnosticLocations a, ReifyKind a, TidyType a, ToText (Type a))
+  => Type a -> Type a -> Location
+  -> Either [ErrorGroup] b -> Either [ErrorGroup] b
+withContext have want loc
+  = mapLeft (++ unificationError Nothing loc have want)
 
-    where commutative = unification type2 type1 program
+{-
+[ErrorGroup [CompileError loc Note
+  (let (have', want') = runTidy $ (liftA2 (,) `on` tidyType) have want
+  in T.unwords
+  $ "expected"
+  : toText (reifyKind (KindProxy :: KindProxy a))
+  : "type"
+  : toText want'
+  : "but got"
+  : toText have'
+  : [])]]
+-}
 
 unificationError
-  :: forall (a :: Kind). (ReifyKind a, TidyType a, ToText (Type a))
+  :: forall (a :: Kind)
+  . (DiagnosticLocations a, ReifyKind a, TidyType a, ToText (Type a))
   => Maybe Text
   -> Location
   -> Type a
   -> Type a
   -> [ErrorGroup]
-unificationError prefix location type1 type2 = runTidy $ do
-  type1' <- tidyType type1
-  type2' <- tidyType type2
+unificationError prefix location have want = runTidy $ do
+  have' <- tidyType have
+  want' <- tidyType want
   let
     primaryError = CompileError location Error $ T.unwords
-      $ "cannot match"
+      $ "expected"
       : prefix `consMaybe` toText kind
       : "type"
-      : toText type1'
-      : "with"
-      : toText type2'
+      : toText want'
+      : "but got"
+      : toText have'
       : []
     secondaryErrors = map errorDetail
-      $ diagnosticLocations type1' ++ diagnosticLocations type2'
+      $ diagnosticLocations have' ++ diagnosticLocations want'
   return [ErrorGroup (primaryError : secondaryErrors)]
   where
   kind = reifyKind (KindProxy :: KindProxy a)
@@ -116,10 +144,10 @@ unifyM
   => Type a
   -> Type a
   -> K (Type a)
-unifyM type1 type2 = do
-  program <- getsProgram $ unify type1 type2
+unifyM have want = do
+  program <- getsProgram $ unify have want
   case program of
-    Right program' -> putProgram program' >> return type2
+    Right program' -> putProgram program' >> return want
     Left errors -> liftFailWriter $ throwMany errors
 
 unifyM_
@@ -129,18 +157,18 @@ unifyM_
   -> K ()
 unifyM_ = (void .) . unifyM
 
-(===)
+shouldBe
   :: (Unification a, Simplify a)
   => Type a
   -> Type a
   -> K ()
-(===) = unifyM_
-
-infix 3 ===
+shouldBe = unifyM_
+infix 3 `shouldBe`
 
 unifyVar
   :: forall a.
   ( Declare a
+  , DiagnosticLocations a
   , Occurrences a
   , ReifyKind a
   , Substitute a

--- a/lib/Kitten/Types.hs
+++ b/lib/Kitten/Types.hs
@@ -61,6 +61,7 @@ data Program = Program
   , programStackIdGen :: !(KindedGen Stack)
   , programSymbols :: !(HashMap Text DefId)
 
+  , inferenceContext :: [Text]
   , inferenceClosure :: !(Vector (Type Scalar))
   , inferenceDefs :: !(HashMap Text TypeScheme)
   , inferenceDecls :: !(HashMap Text TypeScheme)
@@ -158,6 +159,7 @@ emptyProgram = Program
   , programScalarIdGen = mkKindedGen
   , programStackIdGen = mkKindedGen
   , programSymbols = H.empty
+  , inferenceContext = []
   , inferenceClosure = V.empty
   , inferenceDefs = H.empty
   , inferenceDecls = H.empty

--- a/test/Test/Term.hs
+++ b/test/Test/Term.hs
@@ -10,6 +10,7 @@ import Test.HUnit.Lang (assertFailure)
 import Test.Hspec
 
 import qualified Data.HashMap.Strict as H
+import qualified Data.Text as T
 import qualified Data.Vector as V
 
 import Kitten.Error
@@ -19,6 +20,7 @@ import Kitten.Tokenize
 import Kitten.Types
 import Kitten.Util.Either
 import Kitten.Util.Monad
+import Kitten.Util.Text (ToText(..))
 import Test.Util
 
 spec :: Spec
@@ -206,7 +208,7 @@ defList = H.fromList . map (defName &&& id)
 testTerm :: Text -> Fragment ParsedTerm -> Spec
 testTerm source expected = it (show source)
   $ case parsed source of
-    Left message -> assertFailure $ show message
+    Left message -> assertFailure . T.unpack $ toText [message]
     Right actual
       | expected == actual -> noop
       | otherwise -> expectedButGot

--- a/test/instance-checks-1.err.expect
+++ b/test/instance-checks-1.err.expect
@@ -1,3 +1,9 @@
-test/instance-checks-1.ktn:1:1: error: cannot match scalar type int with t1
-test/instance-checks-1.ktn:1:1: note: t1 (from example) is from here
+test/instance-checks-1.ktn:1:1: error: expected scalar type t1 but got int
 test/instance-checks-1.ktn:1:24: note: int is from here
+test/instance-checks-1.ktn:1:1: note: t1 (from example) is from here
+
+test/instance-checks-1.ktn:1:1: error: expected stack type .s2 t1 but got .s1 int
+
+test/instance-checks-1.ktn:1:1: error: expected scalar type (.s2 -> .s2 t1) but got (.s1 -> .s1 int)
+test/instance-checks-1.ktn:1:22: note: (.s1 -> .s1 int) is from here
+test/instance-checks-1.ktn:1:13: note: (.s2 -> .s2 t1) is from here

--- a/test/instance-checks-2.err.expect
+++ b/test/instance-checks-2.err.expect
@@ -1,3 +1,11 @@
-test/instance-checks-2.ktn:1:1: error: cannot match scalar type t1 with t2
+test/instance-checks-2.ktn:1:1: error: expected scalar type t2 but got t1
 test/instance-checks-2.ktn:1:1: note: t1 (type of x) is from here
 test/instance-checks-2.ktn:1:1: note: t2 (from example) is from here
+
+test/instance-checks-2.ktn:1:1: error: expected stack type .s2 t2 but got .s1 t1
+test/instance-checks-2.ktn:1:29: note: t1 (type of x) is from here
+
+test/instance-checks-2.ktn:1:1: error: expected scalar type (.s2 t2 -> .s2 t3) but got (.s1 t1 -> .s1 t1)
+test/instance-checks-2.ktn:1:27: note: (.s1 t1 -> .s1 t1) is from here
+test/instance-checks-2.ktn:1:13: note: (.s2 t2 -> .s2 t3) is from here
+test/instance-checks-2.ktn:1:1: note: t3 (from example) is from here

--- a/test/instance-checks-3.err.expect
+++ b/test/instance-checks-3.err.expect
@@ -1,3 +1,12 @@
-test/instance-checks-3.ktn:1:1: error: cannot match scalar type int with t1
-test/instance-checks-3.ktn:1:1: note: t1 (from example) is from here
+test/instance-checks-3.ktn:1:1: error: expected scalar type t1 but got int
 test/instance-checks-3.ktn:1:13: note: int (type of x) is from here
+test/instance-checks-3.ktn:1:1: note: t1 (from example) is from here
+
+test/instance-checks-3.ktn:1:1: error: expected stack type .s2 t2 but got .s1 t1
+test/instance-checks-3.ktn:1:28: note: t1 (type of x) is from here
+test/instance-checks-3.ktn:1:1: note: t2 (from example) is from here
+
+test/instance-checks-3.ktn:1:1: error: expected scalar type (.s2 t2 -> .s2 int) but got (.s1 t1 -> .s1 t1)
+test/instance-checks-3.ktn:1:26: note: (.s1 t1 -> .s1 t1) is from here
+test/instance-checks-3.ktn:1:13: note: (.s2 t2 -> .s2 int) is from here
+test/instance-checks-3.ktn:1:13: note: int (from example) is from here

--- a/test/instance-checks-4.err.expect
+++ b/test/instance-checks-4.err.expect
@@ -1,3 +1,11 @@
-test/instance-checks-4.ktn:1:1: error: cannot match scalar type t1 with int
+test/instance-checks-4.ktn:1:1: error: expected scalar type int but got t1
 test/instance-checks-4.ktn:1:1: note: t1 (from example) is from here
 test/instance-checks-4.ktn:1:13: note: int (from example) is from here
+
+test/instance-checks-4.ktn:1:1: error: expected stack type .s1 int but got .s1 t1
+
+test/instance-checks-4.ktn:1:1: error: expected stack type .s1 int t1 but got .s1 t1 t1
+
+test/instance-checks-4.ktn:1:1: error: expected scalar type (.s2 int t1 -> .s2 t1 t1) but got (.s1 -> .s1)
+test/instance-checks-4.ktn:1:31: note: (.s1 -> .s1) is from here
+test/instance-checks-4.ktn:1:13: note: (.s2 int t1 -> .s2 t1 t1) is from here

--- a/test/instance-checks-5.err.expect
+++ b/test/instance-checks-5.err.expect
@@ -1,3 +1,9 @@
-test/instance-checks-5.ktn:1:1: error: cannot match scalar type t1 with t2
+test/instance-checks-5.ktn:1:1: error: expected scalar type t2 but got t1
 test/instance-checks-5.ktn:1:1: note: t1 (from example) is from here
 test/instance-checks-5.ktn:1:1: note: t2 (from example) is from here
+
+test/instance-checks-5.ktn:1:1: error: expected stack type .s1 t2 but got .s1 t1
+
+test/instance-checks-5.ktn:1:1: error: expected scalar type (.s2 t1 -> .s2 t2) but got (.s1 -> .s1)
+test/instance-checks-5.ktn:1:28: note: (.s1 -> .s1) is from here
+test/instance-checks-5.ktn:1:13: note: (.s2 t1 -> .s2 t2) is from here

--- a/test/instance-checks-6.err.expect
+++ b/test/instance-checks-6.err.expect
@@ -1,3 +1,9 @@
-test/instance-checks-6.ktn:1:1: error: cannot match scalar type int with t1
-test/instance-checks-6.ktn:1:1: note: t1 (from example) is from here
+test/instance-checks-6.ktn:1:1: error: expected scalar type t1 but got int
 test/instance-checks-6.ktn:1:13: note: int (from example) is from here
+test/instance-checks-6.ktn:1:1: note: t1 (from example) is from here
+
+test/instance-checks-6.ktn:1:1: error: expected stack type .s1 t1 but got .s1 int
+
+test/instance-checks-6.ktn:1:1: error: expected scalar type (.s2 t1 -> .s2 int) but got (.s1 -> .s1)
+test/instance-checks-6.ktn:1:27: note: (.s1 -> .s1) is from here
+test/instance-checks-6.ktn:1:13: note: (.s2 t1 -> .s2 int) is from here

--- a/test/instance-checks-7.err.expect
+++ b/test/instance-checks-7.err.expect
@@ -1,4 +1,6 @@
-test/instance-checks-7.ktn:1:1: error: cannot match stack type .s1 t1 with .s2
-test/instance-checks-7.ktn:1:1: note: .s2 (type of example) is from here
+test/instance-checks-7.ktn:1:1: error: expected stack type .s2 but got .s1 t1
 test/instance-checks-7.ktn:1:19: note: t1 (type of x) is from here
-test/instance-checks-7.ktn:1:24: note: .s1 is from here
+
+test/instance-checks-7.ktn:1:1: error: expected scalar type (.s2 -> .s2) but got (.s1 t1 -> .s1 t1)
+test/instance-checks-7.ktn:1:17: note: (.s1 t1 -> .s1 t1) is from here
+test/instance-checks-7.ktn:1:13: note: (.s2 -> .s2) (type of example) is from here

--- a/test/instance-checks-8.err.expect
+++ b/test/instance-checks-8.err.expect
@@ -1,5 +1,9 @@
-test/instance-checks-8.ktn:1:1: error: cannot match stack type .s1 t1 t2 with .s2
-test/instance-checks-8.ktn:1:1: note: .s2 (type of example) is from here
+test/instance-checks-8.ktn:1:1: error: expected stack type .s2 but got .s1 t1 t2
 test/instance-checks-8.ktn:1:19: note: t1 (type of y) is from here
 test/instance-checks-8.ktn:1:19: note: t2 (type of x) is from here
-test/instance-checks-8.ktn:1:26: note: .s1 is from here
+
+test/instance-checks-8.ktn:1:1: error: expected scalar type (.s2 -> .s2) but got (.s1 t1 t2 -> .s1 t2 t1)
+test/instance-checks-8.ktn:1:17: note: (.s1 t1 t2 -> .s1 t2 t1) is from here
+test/instance-checks-8.ktn:1:19: note: t1 (type of x) is from here
+test/instance-checks-8.ktn:1:19: note: t2 (type of y) is from here
+test/instance-checks-8.ktn:1:13: note: (.s2 -> .s2) (type of example) is from here

--- a/test/instance-checks-9.err.expect
+++ b/test/instance-checks-9.err.expect
@@ -1,3 +1,14 @@
-test/instance-checks-9.ktn:1:1: error: cannot match scalar type t1 with int
+test/instance-checks-9.ktn:1:1: error: expected scalar type int but got t1
 test/instance-checks-9.ktn:1:1: note: t1 (type of x) is from here
 test/instance-checks-9.ktn:1:13: note: int (from example) is from here
+
+test/instance-checks-9.ktn:1:1: error: expected stack type .s2 int but got .s1 t1
+test/instance-checks-9.ktn:1:32: note: t1 (type of x) is from here
+
+test/instance-checks-9.ktn:1:1: error: expected stack type .s2 int t3 but got .s1 t1 t2
+test/instance-checks-9.ktn:1:32: note: t2 (type of y) is from here
+test/instance-checks-9.ktn:1:1: note: t3 (from example) is from here
+
+test/instance-checks-9.ktn:1:1: error: expected scalar type (.s2 int t3 -> .s2 t3 t3) but got (.s1 t1 t2 -> .s1 t1 t2)
+test/instance-checks-9.ktn:1:30: note: (.s1 t1 t2 -> .s1 t1 t2) is from here
+test/instance-checks-9.ktn:1:13: note: (.s2 int t3 -> .s2 t3 t3) is from here

--- a/test/stack-effects-1.err.expect
+++ b/test/stack-effects-1.err.expect
@@ -1,4 +1,9 @@
-test/stack-effects-1.ktn:1:4: error: cannot match stack type .s1 t1 with .s2
-test/stack-effects-1.ktn:1:4: note: .s1 is from here
+test/stack-effects-1.ktn:1:4: error: expected stack type .s2 but got .s1 t1
 test/stack-effects-1.ktn:1:4: note: t1 (from dup) is from here
-test/stack-effects-1.ktn:1:4: note: .s2 is from here
+
+test/stack-effects-1.ktn:1:4: error: expected stack type .s2 t2 but got .s1 t1 t1
+test/stack-effects-1.ktn:1:4: note: t2 is from here
+
+test/stack-effects-1.ktn:1:4: error: expected scalar type (.s2 -> .s2 t2) but got (.s1 t1 -> .s1 t1 t1)
+test/stack-effects-1.ktn:1:4: note: (.s1 t1 -> .s1 t1 t1) is from here
+test/stack-effects-1.ktn:1:4: note: (.s2 -> .s2 t2) is from here

--- a/test/stack-effects-2.err.expect
+++ b/test/stack-effects-2.err.expect
@@ -1,4 +1,10 @@
-test/stack-effects-2.ktn:1:6: error: cannot match stack type .s1 int with .s2
+test/stack-effects-2.ktn:1:6: error: expected stack type .s2 but got .s1 int
 test/stack-effects-2.ktn:1:2: note: int is from here
-test/stack-effects-2.ktn:1:6: note: .s1 is from here
-test/stack-effects-2.ktn:1:6: note: .s2 is from here
+
+test/stack-effects-2.ktn:1:6: error: expected stack type .s2 t1 but got .s1 int int
+test/stack-effects-2.ktn:1:4: note: int is from here
+test/stack-effects-2.ktn:1:6: note: t1 is from here
+
+test/stack-effects-2.ktn:1:6: error: expected scalar type (.s2 -> .s2 t1) but got (.s1 -> .s1 int int)
+test/stack-effects-2.ktn:1:6: note: (.s1 -> .s1 int int) is from here
+test/stack-effects-2.ktn:1:6: note: (.s2 -> .s2 t1) is from here

--- a/test/type-error-1.err.expect
+++ b/test/type-error-1.err.expect
@@ -1,4 +1,9 @@
-test/type-error-1.ktn:4:8: error: cannot match scalar type [t1] with int
+test/type-error-1.ktn:4:8: error: expected scalar type int but got [t1]
 test/type-error-1.ktn:4:8: note: [t1] is from here
 test/type-error-1.ktn:4:8: note: t1 is from here
 test/type-error-1.ktn:4:14: note: int (input to __add_int) is from here
+
+test/type-error-1.ktn:4:8: error: expected stack type .s2 int but got .s1 [t1]
+
+test/type-error-1.ktn:4:8: error: expected stack type .s2 int int but got .s1 int
+test/type-error-1.ktn:4:12: note: int is from here

--- a/test/type-error-2.err.expect
+++ b/test/type-error-2.err.expect
@@ -1,3 +1,13 @@
-test/type-error-2.ktn:3:1: error: cannot match scalar type [t1] with int
-test/type-error-2.ktn:3:9: note: int (from baz) is from here
+test/type-error-2.ktn:3:1: error: expected scalar type int but got [t1]
 test/type-error-2.ktn:4:12: note: [t1] (output of __add_vector) is from here
+test/type-error-2.ktn:3:9: note: int (from baz) is from here
+
+test/type-error-2.ktn:3:1: error: expected stack type .s2 int but got .s1 [t1]
+
+test/type-error-2.ktn:3:1: error: expected scalar type (.s2 [t2] [char] -> .s2 int) but got (.s1 [t1] t1 -> .s1 [t1])
+test/type-error-2.ktn:3:31: note: (.s1 [t1] t1 -> .s1 [t1]) is from here
+test/type-error-2.ktn:4:12: note: [t1] (input to __add_vector) is from here
+test/type-error-2.ktn:4:12: note: t1 (type of x) is from here
+test/type-error-2.ktn:3:9: note: (.s2 [t2] [char] -> .s2 int) is from here
+test/type-error-2.ktn:3:9: note: [t2] (input to baz) is from here
+test/type-error-2.ktn:3:9: note: [char] (input to baz) is from here

--- a/test/type-error-3.err.expect
+++ b/test/type-error-3.err.expect
@@ -1,3 +1,14 @@
-test/type-error-3.ktn:3:1: error: cannot match scalar type char with [char]
+test/type-error-3.ktn:3:1: error: expected scalar type [char] but got char
 test/type-error-3.ktn:3:9: note: char (type of x) is from here
 test/type-error-3.ktn:3:9: note: [char] (input to baq) is from here
+
+test/type-error-3.ktn:3:1: error: expected stack type .s2 [char] but got .s1 t1
+test/type-error-3.ktn:5:3: note: t1 (type of x) is from here
+
+test/type-error-3.ktn:3:1: error: expected stack type .s2 [char] [char] but got .s1 t1 [t2]
+test/type-error-3.ktn:4:12: note: [t2] (type of q) is from here
+
+test/type-error-3.ktn:3:1: error: expected scalar type (.s2 [char] [char] -> .s2 char) but got (.s1 t1 [t2] -> .s1 t1)
+test/type-error-3.ktn:3:32: note: (.s1 t1 [t2] -> .s1 t1) is from here
+test/type-error-3.ktn:3:9: note: (.s2 [char] [char] -> .s2 char) (type of baq) is from here
+test/type-error-3.ktn:3:9: note: char (from baq) is from here

--- a/test/type-error-4.err.expect
+++ b/test/type-error-4.err.expect
@@ -1,3 +1,11 @@
-test/type-error-4.ktn:1:1: error: cannot match scalar type t1? with [t2]
-test/type-error-4.ktn:1:9: note: [t2] (input to foo) is from here
+test/type-error-4.ktn:1:1: error: expected scalar type [t2] but got t1?
 test/type-error-4.ktn:2:10: note: t1 is from here
+test/type-error-4.ktn:1:9: note: [t2] (input to foo) is from here
+
+test/type-error-4.ktn:1:1: error: expected stack type .s2 [t2] but got .s1 t1?
+
+test/type-error-4.ktn:1:1: error: expected scalar type (.s2 [t2] -> .s2 t2) but got (.s1 t1? -> .s1 t1)
+test/type-error-4.ktn:1:22: note: (.s1 t1? -> .s1 t1) is from here
+test/type-error-4.ktn:2:10: note: t1 (output of __from_some) is from here
+test/type-error-4.ktn:1:9: note: (.s2 [t2] -> .s2 t2) is from here
+test/type-error-4.ktn:1:1: note: t2 (from foo) is from here

--- a/test/type-error-5.err.expect
+++ b/test/type-error-5.err.expect
@@ -1,3 +1,13 @@
-test/type-error-5.ktn:5:1: error: cannot match scalar type [t1] with int
+test/type-error-5.ktn:5:1: error: expected scalar type int but got [t1]
 test/type-error-5.ktn:3:17: note: [t1] (output of myAddVector) is from here
 test/type-error-5.ktn:5:9: note: int (from bar) is from here
+
+test/type-error-5.ktn:5:1: error: expected stack type .s2 int but got .s1 [t1]
+
+test/type-error-5.ktn:5:1: error: expected scalar type (.s2 [t2] [char] -> .s2 int) but got (.s1 [t1] t1 -> .s1 [t1])
+test/type-error-5.ktn:5:31: note: (.s1 [t1] t1 -> .s1 [t1]) is from here
+test/type-error-5.ktn:3:17: note: [t1] (input to myAddVector) is from here
+test/type-error-5.ktn:6:12: note: t1 (type of x) is from here
+test/type-error-5.ktn:5:9: note: (.s2 [t2] [char] -> .s2 int) is from here
+test/type-error-5.ktn:5:9: note: [t2] (input to bar) is from here
+test/type-error-5.ktn:5:9: note: [char] (input to bar) is from here

--- a/test/type-error-6.err.expect
+++ b/test/type-error-6.err.expect
@@ -1,3 +1,13 @@
-test/type-error-6.ktn:3:1: error: cannot match scalar type [t1] with int
+test/type-error-6.ktn:3:1: error: expected scalar type int but got [t1]
 test/type-error-6.ktn:1:17: note: [t1] (output of myAddVector) is from here
 test/type-error-6.ktn:3:9: note: int (from bar) is from here
+
+test/type-error-6.ktn:3:1: error: expected stack type .s2 int but got .s1 [t1]
+
+test/type-error-6.ktn:3:1: error: expected scalar type (.s2 [t2] [char] -> .s2 int) but got (.s1 [t1] t1 -> .s1 [t1])
+test/type-error-6.ktn:3:31: note: (.s1 [t1] t1 -> .s1 [t1]) is from here
+test/type-error-6.ktn:1:17: note: [t1] (input to myAddVector) is from here
+test/type-error-6.ktn:4:12: note: t1 (type of x) is from here
+test/type-error-6.ktn:3:9: note: (.s2 [t2] [char] -> .s2 int) is from here
+test/type-error-6.ktn:3:9: note: [t2] (input to bar) is from here
+test/type-error-6.ktn:3:9: note: [char] (input to bar) is from here


### PR DESCRIPTION
Experimentation on #122. Surprisingly, it’s clear most of the time which is the “expected” type and which is the “actual” type, and the order was correct in most cases. The most helpful thing is to include the full context of unification when an error occurs, though it makes type error messages significantly longer even with deduplication.
