### PR TITLE
Simplify the layout rule.

### DIFF
--- a/examples/brainfuck.ktn
+++ b/examples/brainfuck.ktn
@@ -196,7 +196,8 @@ def dumpMemory ([int] int ->):
   -> ram ramc;
 
   "Memory:" say
-  upto 32: -> index;
+  upto 32:
+    -> index;
     ram @! index -> cell;
     ["[", index showInt, "] ", cell showInt] concat print
     if (index = ramc): " <" print

--- a/examples/tictactoe.ktn
+++ b/examples/tictactoe.ktn
@@ -48,7 +48,8 @@ def askTurn ([char] char -> [char]):
   getLine -> input;
   input readMoveLine -> mxy;
 
-  option (mxy): -> xy;
+  option (mxy):
+    -> xy;
     board
     xy first xy rest xyToCellNumber
     player editBoard

--- a/lib/Prelude_Control.ktn
+++ b/lib/Prelude_Control.ktn
@@ -65,7 +65,8 @@ def cond {a, b, c}(
   c
 ):
   -> x ps z;
-  option (ps head): -> p;
+  option (ps head):
+    -> p;
     x p first apply -> m;
     option (m):
       p rest apply

--- a/lib/Prelude_Option.ktn
+++ b/lib/Prelude_Option.ktn
@@ -36,8 +36,10 @@ def liftOption {a, b}(a? (a -> b) -> b?):
 // Combines two option values with a function.
 def liftOption2 {a, b, c}(a? b? (a b -> c) -> c?):
   -> mx my f;
-  option (mx): -> x;
-    option (my): -> y;
+  option (mx):
+    -> x;
+    option (my):
+      -> y;
       x y f apply some
     else: none
   else: none

--- a/lib/Prelude_Read.ktn
+++ b/lib/Prelude_Read.ktn
@@ -2,7 +2,8 @@
 def readInt ([char] -> int?):
   -> s;
   none
-  option (s last): -> c;
+  option (s last):
+    -> c;
     if (c {'0' geChar} {'9' leChar} bothTo (&&)):
       drop;
       c '0' \charToInt toBoth (-);

--- a/lib/Prelude_Vector.ktn
+++ b/lib/Prelude_Vector.ktn
@@ -10,8 +10,10 @@ def cartesian {a, b}([a] [b] -> [a & b]):
 // tupling function.
 def cartesianWith {a, b, c}([a] [b] (a b -> c) -> [c]):
   -> xs ys function;
-  forConcat (xs): -> x;
-    for (ys): -> y;
+  forConcat (xs):
+    -> x;
+    for (ys):
+      -> y;
       x y function apply
 
 // Concatenates two vectors.
@@ -60,7 +62,8 @@ def eqVector {a}([a] [a] (a a -> bool) -> bool):
 // Filters a vector by a predicate.
 def filter {a}([a] (a -> bool) -> [a]):
   -> v f;
-  option (v head): -> x;
+  option (v head):
+    -> x;
     if (x f apply):
       v tail f filter
       x prepend
@@ -76,7 +79,8 @@ def find {a}([a] (a -> bool) -> a?):
 // Folds elements of a vector right-associatively.
 def foldr {a, b}([a] b (a b -> b) -> b):
   -> xs z k;
-  option (xs last): -> x;
+  option (xs last):
+    -> x;
     (xs init) (x z k apply) k foldr
   else:
     z
@@ -84,14 +88,16 @@ def foldr {a, b}([a] b (a b -> b) -> b):
 // Right-associative non-empty vector fold.
 def foldr1 {a}([a] (a a -> a) -> a?):
   -> xs fn;
-  option (xs last): -> x;
+  option (xs last):
+    -> x;
     (xs init) x fn foldr some
   else:
     none
 
 def generateN {a}((int -> a) int -> [a]):
   -> f size;
-  from (0) unfold (size): -> index;
+  from (0) unfold (size):
+    -> index;
     index f apply;
     index + 1
 
@@ -112,7 +118,8 @@ def unsafeFoldr1 {a}([a] (a a -> a) -> a):
 // Folds elements of a vector left-associatively.
 def foldl {a, b}([b] a (a b -> a) -> a):
   -> xs z k;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     xs tail (z x k apply) k foldl
   else:
     z
@@ -120,7 +127,8 @@ def foldl {a, b}([b] a (a b -> a) -> a):
 // Left-associative non-empty vector fold.
 def foldl1 {a}([a] (a a -> a) -> a?):
   -> xs fn;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     xs tail x fn foldl some
   else:
     none
@@ -168,7 +176,8 @@ def init {a}([a] -> [a]):
 // the main diagonal and xs wrapped to the remainder.
 def insertEverywhere {a}([a] a -> [[a]]):
   -> xs n;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     (xs tail) n insertEverywhere
     {x prepend} map
     (xs n prepend)
@@ -178,7 +187,8 @@ def insertEverywhere {a}([a] a -> [[a]]):
 
 def insert {a}([a] a (a a -> bool) -> [a]):
   -> xs n lt;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     if (x n lt apply):
       (xs tail) n lt insert
       x prepend
@@ -190,7 +200,8 @@ def insert {a}([a] a (a a -> bool) -> [a]):
 // Intersperses a value between the values of a vector.
 def intersperse {a}([a] a -> [a]):
   -> xs sep;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     xs tail sep prependToAll
     x prepend
   else:
@@ -210,7 +221,8 @@ def keep {a}([a] int -> [a]):
   if (n <= 0):
     []
   else:
-    option (xs head): -> x;
+    option (xs head):
+      -> x;
       xs tail (n - 1) keep
       x prepend
     else:
@@ -220,7 +232,8 @@ def keep {a}([a] int -> [a]):
 def keepWhile {a}([a] (a -> bool) -> [a]):
   -> xs f;
   []
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     if (x f apply):
       drop
       xs tail f keepWhile
@@ -284,7 +297,8 @@ def prepend {a}([a] a -> [a]):
 
 def prependToAll {a}([a] a -> [a]):
   -> xs sep;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     xs tail sep prependToAll
     x prepend
     sep prepend
@@ -303,7 +317,8 @@ def replicate {a}(a int -> [a]):
 // Reverses a vector.
 def reverse {a}([a] -> [a]):
   -> xs;
-  option (xs last): -> x;
+  option (xs last):
+    -> x;
     xs init reverse
     x prepend
   else:
@@ -322,7 +337,8 @@ def scanl1 {a}([a] (a a -> a) -> [a]):
 // Scan fold of remaining elements
 def scanlRest {a, b}([b] a (a b -> a) -> [a]):
   -> xs z k;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     z x k apply -> q;
     xs tail q k scanlRest
     q prepend
@@ -332,7 +348,8 @@ def scanlRest {a, b}([b] a (a b -> a) -> [a]):
 // Produce a list of fold-right results
 def scanr {a, b}([a] b (a b -> b) -> [b]):
   -> xs z k;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     (xs tail) z k scanr dup unsafeHead
     x swap k apply
     prepend
@@ -375,7 +392,8 @@ def toss {a}([a] int -> [a]):
 def tossWhile {a}([a] (a -> bool) -> [a]):
   -> xs f;
   xs
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     if (x f apply):
       tail f tossWhile
 
@@ -398,7 +416,8 @@ def transpose {a}([[a]] -> [[a]]):
 // given equality predicate.
 def unique {a}([a] (a a -> bool) -> [a]):
   -> xs eq;
-  option (xs head): -> x;
+  option (xs head):
+    -> x;
     (xs tail {x (eq apply) not} filter) eq unique
     x prepend
   else:
@@ -425,8 +444,10 @@ def zip {a, b}([a] [b] -> [a & b]):
 def zipWith {a, b, c}([a] [b] (a b -> c) -> [c]):
   -> as bs f;
   []
-  option (as head): -> a;
-    option (bs head): -> b;
+  option (as head):
+    -> a;
+    option (bs head):
+      -> b;
       drop
       (as tail) (bs tail) f zipWith
       a b f apply; prepend

--- a/test/Test/Term.hs
+++ b/test/Test/Term.hs
@@ -153,6 +153,14 @@ spec = do
       \  3\n"
       . termFragment . push $ quotation [push $ quotation [pushi 3]]
 
+    testTerm
+      ": : 1\n\
+      \    2\n\
+      \  3\n"
+      . termFragment . push $ quotation
+        [push $ quotation [pushi 1, pushi 2], pushi 3]
+
+
   describe "definition" $ do
 
     testTerm

--- a/test/levenshtein.ktn
+++ b/test/levenshtein.ktn
@@ -10,15 +10,19 @@ def levenshtein ([char] [char] -> int):
   0 (columns + 1) replicate (rows + 1) replicate
 
   // Distance from any first string to empty second string.
-  from (0) to (rows): -> row;
+  from (0) to (rows):
+    -> row;
     (row, 0) @@= row
 
   // Distance from any second string to empty first string.
-  from (0) to (columns): -> column;
+  from (0) to (columns):
+    -> column;
     (0, column) @@= column
 
-  from (1) to (rows): -> row;
-    from (1) to (columns): -> distances column;
+  from (1) to (rows):
+    -> row;
+    from (1) to (columns):
+      -> distances column;
 
       first @! (row - 1) -> firstChar;
       second @! (column - 1) -> secondChar;


### PR DESCRIPTION
Previously, this:

```
foo : bar : baz
            quux
      blerg
```

Would desugar to this:

```
foo { bar { baz
            quux
      blerg } }
```

Because `blerg` is indented more than the line containing the most
recent colon, following `bar`. The desugaring that the programmer
almost certainly intended is this:

```
foo { bar { baz
            quux }
      blerg }
```

This caused problems with line-wrapped conditionals:

```
if (this
    || that
    || anotherThing):
  take
  some
  actions
```

Here, `take some actions` would be interpreted as falling _outside_ the
block, because they are indented less than the layout line, which begins
with `||` and not `if`.

The new, simplified layout rule is that all tokens in a layout block
must be indented at least as far as the first token in the block. That
leads naturally to a few legal styles:

```
// Colons at the end of the line with consistent spacing.
if (quux):
  foo
  if (bar):
    baz
    frob
  blerg

// Colons before a block with consistent spacing.
if (quux)
: foo
  if (bar)
  : baz
    frob
  blerg

// Colons before an aligned block with inconsistent spacing.
if (quux): foo
           if (bar): baz
                     frob
           blerg
```
