### PR TITLE
Added ftdetect for vim

### DIFF
--- a/ftdetect/kitten.vim
+++ b/ftdetect/kitten.vim
@@ -1,0 +1,5 @@
+" Vim syntax file
+" Language: Kitten
+" Maintainer: Jon Purdy <evincarofautumn@gmail.com>
+
+autocmd BufNewFile,BufRead *.ktn setfiletype kitten


### PR DESCRIPTION
Assuming kitten/ is added to the runtime path, using

``` viml
set runtimepath^=~/projects/kitten
```

or via some manager such as vundle, kitten files will now automatically
be detected.
