### PR TITLE
test/run.sh: do not quote $CC

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -79,7 +79,7 @@ function run_test {
       if [ $? -ne 0 ]; then
         return
       fi
-      if ! "$CC" "$test_file.c" $CFLAGS -o "$test_file.built" \
+      if ! $CC "$test_file.c" $CFLAGS -o "$test_file.built" \
         > "$test_file.info" 2>&1; then
         echo "Test '$test_name' ($mode) FAILED." >&2
         echo "The generated program did not compile:" >&2


### PR DESCRIPTION
e.g. on my setup CC is set to:
> export CC='ccache gcc'