### PR TITLE
Simplify terms.

### DIFF
--- a/new/lib/Kitten.hs
+++ b/new/lib/Kitten.hs
@@ -51,6 +51,5 @@ compile mainPermissions mainName paths = do
   parsed <- mconcat <$> zipWithM
     (Enter.fragmentFromSource mainPermissions mainName 1)
     paths sources
-  -- dictionary <-
-  Enter.fragment parsed Dictionary.empty
-  -- collectInstantiations dictionary
+  dictionary <- Enter.fragment parsed Dictionary.empty
+  collectInstantiations dictionary

--- a/new/lib/Kitten/Amd64.hs
+++ b/new/lib/Kitten/Amd64.hs
@@ -94,7 +94,6 @@ term t = case t of
     term b
   Term.Generic{} -> error
     "uninstantiated term appeared during code generation"
-  Term.Group a -> term a
   Term.Lambda _ _ type_ a _ -> do
     -- TODO: Use actual size class.
     let size = Large type_

--- a/new/lib/Kitten/CollectInstantiations.hs
+++ b/new/lib/Kitten/CollectInstantiations.hs
@@ -91,7 +91,6 @@ collectInstantiations dictionary0 = do
 -- instantiations in it, because it's not instantiated itself!
 
     Generic{} -> proceed
-    Group{} -> error "group should not appear after linearization"
     Lambda type_ name varType body origin -> do
       (body', q1) <- go q0 body
       return (Lambda type_ name varType body' origin, q1)

--- a/new/lib/Kitten/Enter.hs
+++ b/new/lib/Kitten/Enter.hs
@@ -166,7 +166,7 @@ declareWord dictionary definition = let
       -> do
       let qualifier = qualifierName name
       resolvedSignature <- Resolve.run $ Resolve.signature
-        dictionary qualifier $ Definition.signature definition
+        dictionary qualifier [] $ Definition.signature definition
       mangledName <- mangleInstance dictionary
         (Definition.name definition)
         resolvedSignature traitSignature
@@ -208,12 +208,14 @@ resolveSignature dictionary name = do
   let qualifier = qualifierName name
   case Dictionary.lookup (Instantiated name []) dictionary of
     Just (Entry.Word category merge origin parent (Just signature) body) -> do
-      signature' <- Resolve.run $ Resolve.signature dictionary qualifier signature
+      signature' <- Resolve.run
+        $ Resolve.signature dictionary qualifier [] signature
       let
         entry = Entry.Word category merge origin parent (Just signature') body
       return $ Dictionary.insert (Instantiated name []) entry dictionary
     Just (Entry.Trait origin signature) -> do
-      signature' <- Resolve.run $ Resolve.signature dictionary qualifier signature
+      signature' <- Resolve.run
+        $ Resolve.signature dictionary qualifier [] signature
       let entry = Entry.Trait origin signature'
       return $ Dictionary.insert (Instantiated name []) entry dictionary
     _ -> return dictionary

--- a/new/lib/Kitten/Interpret.hs
+++ b/new/lib/Kitten/Interpret.hs
@@ -116,7 +116,6 @@ interpret dictionary mName mainArgs stdin' stdout' _stderr' initialStack = do
       Compose _ a b -> term a >> term b
       -- TODO: Verify that this is correct.
       Generic _ t' _ -> term t'
-      Group t' -> term t'
       Lambda _ _name _ body _ -> do
         (a : r) <- readIORef stackRef
         ls <- readIORef localsRef
@@ -167,11 +166,10 @@ interpret dictionary mName mainArgs stdin' stdout' _stderr' initialStack = do
 
     call :: IO ()
     call = do
-      (Closure name closure : r) <- readIORef stackRef
+      (Closure (Instantiated name args) closure : r) <- readIORef stackRef
       writeIORef stackRef r
       modifyIORef' currentClosureRef (closure :)
-      -- FIXME: Use right args.
-      word name []
+      word name args
       modifyIORef' currentClosureRef tail
 
     push :: Value Type -> IO ()

--- a/new/lib/Kitten/Linearize.hs
+++ b/new/lib/Kitten/Linearize.hs
@@ -46,7 +46,6 @@ linearize = snd . go []
     Generic x body origin -> let
       (counts1, body') = go counts0 body
       in (counts1, Generic x body' origin)
-    Group{} -> error "group should not appear after desugaring"
     Lambda type_ x varType body origin -> let
       (n : counts1, body') = go (0 : counts0) body
       body'' = case n of
@@ -103,7 +102,6 @@ instrumentCopy varType = go 0
     Coercion{} -> term
     Compose type_ a b -> Compose type_ (go n a) (go n b)
     Generic x body origin -> Generic x (go n body) origin
-    Group{} -> error "group should not appear after desugaring"
     Lambda type_ name varType' body origin
       -> Lambda type_ name varType' (go (succ n) body) origin
     Match hint type_ cases else_ origin

--- a/new/lib/Kitten/Scope.hs
+++ b/new/lib/Kitten/Scope.hs
@@ -21,6 +21,10 @@ import Data.List (elemIndex)
 import Kitten.Name (Closed(..), ClosureIndex(..), GeneralName(..), LocalIndex(..))
 import Kitten.Term (Case(..), Else(..), Term(..), Value(..))
 
+import Debug.Trace
+import qualified Text.PrettyPrint as Pretty
+import Text.PrettyPrint.HughesPJClass (Pretty(..))
+
 -- | Whereas name resolution is concerned with resolving references to
 -- definitions, scope resolution resolves local names to relative (De Bruijn)
 -- indices, and converts 'Quotation's to explicit 'Capture's.
@@ -39,8 +43,6 @@ scope = scopeTerm [0]
       Compose _ a b -> Compose () (recur a) (recur b)
       Generic{} -> error
         "generic expression should not appear before scope resolution"
-      Group{} -> error
-        "group expression should not appear after infix desugaring"
       Lambda _ name _ a origin -> Lambda () name ()
         (scopeTerm (mapHead succ stack) a) origin
       Match hint _ cases else_ origin -> Match hint ()
@@ -103,8 +105,6 @@ captureTerm term = case term of
   Compose _ a b -> Compose () <$> captureTerm a <*> captureTerm b
   Generic{} -> error
     "generic expression should not appear before scope resolution"
-  Group{} -> error
-    "group expression should not appear after infix desugaring"
   Lambda _ name _ a origin -> let
     inside env = env
       { scopeStack = mapHead succ (scopeStack env)

--- a/new/lib/Kitten/Substitute.hs
+++ b/new/lib/Kitten/Substitute.hs
@@ -51,7 +51,6 @@ term tenv x a = recur
       z <- freshTypeId tenv
       body' <- term tenv x' (TypeVar origin $ Var z k) body
       Generic z <$> recur body' <*> pure origin
-    Group body -> recur body
     Lambda tref name varType body origin -> Lambda <$> go tref
       <*> pure name <*> go varType <*> recur body <*> pure origin
     Match hint tref cases else_ origin -> Match hint <$> go tref

--- a/new/lib/Kitten/Zonk.hs
+++ b/new/lib/Kitten/Zonk.hs
@@ -19,6 +19,10 @@ import Kitten.TypeEnv (TypeEnv)
 import qualified Data.Map as Map
 import qualified Kitten.TypeEnv as TypeEnv
 
+import Text.PrettyPrint.HughesPJClass (Pretty(..))
+import qualified Text.PrettyPrint as Pretty
+import qualified Kitten.Kind as Kind
+
 -- | Zonking a type fully substitutes all type variables. That is, if you have:
 --
 -- > t0 ~ t1
@@ -32,9 +36,9 @@ type_ tenv0 = recur
   recur t = case t of
     TypeConstructor{} -> t
     TypeValue{} -> error "TODO: zonk type value"
-    TypeVar _origin (Var x _k) -> case Map.lookup x (TypeEnv.tvs tenv0) of
+    TypeVar _origin (Var x k) -> case Map.lookup x (TypeEnv.tvs tenv0) of
       -- FIXME: Is this necessary?
-      -- Just (TypeVar _origin (Var x' _)) | x == x' -> TypeVar origin (Var x k)
+      -- Just (TypeVar origin (Var x' _)) | x == x' -> TypeVar origin (Var x k)
       Just t' -> recur t'
       Nothing -> t
     TypeConstant{} -> t
@@ -57,8 +61,6 @@ term tenv0 = go
       -> Compose (zonk tref) (go a) (go b)
     Generic x a origin
       -> Generic x (go a) origin
-    Group a
-      -> go a
     Lambda tref name varType body origin
       -> Lambda (zonk tref) name (zonk varType) (go body) origin
     Match hint tref cases else_ origin

--- a/new/test/Test/Interpret.hs
+++ b/new/test/Test/Interpret.hs
@@ -8,6 +8,7 @@ import Data.ByteString (ByteString)
 import Data.Text (Text)
 import Kitten (fragmentFromSource)
 import Kitten.Bits
+import Kitten.CollectInstantiations (collectInstantiations)
 import Kitten.Dictionary (Dictionary)
 import Kitten.Interpret (interpret)
 import Kitten.Monad (runKitten)

--- a/new/test/Test/Resolve.hs
+++ b/new/test/Test/Resolve.hs
@@ -200,8 +200,8 @@ testType contextSource viewpoint name expected = do
     context <- fragmentFromSource [] Nothing 1 "<common>" contextSource
     contextDictionary <- Enter.fragment context Dictionary.empty
     let origin = Origin.point "<test>" 0 0
-    Resolve.run $ Resolve.signature contextDictionary viewpoint
-      (Signature.Variable name origin)
+    Resolve.run $ Resolve.signature contextDictionary viewpoint []
+      $ Signature.Variable name origin
   case resolved of
     Right (Signature.Variable name' _) -> let
       message = Pretty.render $ Pretty.hsep


### PR DESCRIPTION
The `Group` constructor is redundant because `(x)` is equivalent to `{x} call`, and `Group` is only used for infix desugaring, after which it just gets in the way. This is a work in progress—currently, the compiler can fail to find the right instantiation of the definition generated by lifting the intermediate quotation. In the future, optimisations will be able to remove this unnecessary closure, but this issue needs to be fixed anyway.

Since a quotation is only ever used at a single type, we should be able to generate the correct instantiation immediately.
