### PR TITLE
Update build instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ To build the latest compiler, you need [Stack]:
 
 ```
 git clone https://github.com/evincarofautumn/kitten.git
-cd kitten/new
+cd kitten
+stack setup
 stack build
 
 stack exec kitten


### PR DESCRIPTION
The build instructions in the README have two problems:

* The 'new' directory no longer exists (as of commit
  0e90db1eb176f133607b5e091c1d267845e1fdfd).
* 'stack build' requires 'stack setup' to install GHC.

Fix the instructions to resolve these issues.