### PR TITLE
Fix permission variable elision

### DIFF
--- a/common.ktn
+++ b/common.ktn
@@ -1124,7 +1124,7 @@ define exit<R..., S...> (R..., Int32 -> S... +Exit):
 define fail<R..., S...> (R..., List<Char> -> S... +Fail):
   _::kitten::abort
 
-define assert<+P> (List<Char>, (-> Bool +P) -> +Fail +P):
+define assert (List<Char>, (-> Bool) -> +Fail):
   -> message, test;
   do (with (-Fail)):
     test call

--- a/lib/Kitten/Parse.hs
+++ b/lib/Kitten/Parse.hs
@@ -715,6 +715,8 @@ termParser = (<?> "expression") $ do
   withParser = (<?> "'with' expression") $ do
     origin <- getTokenOrigin <* parserMatch_ Token.With
     permits <- groupedParser $ Parsec.many1 permitParser
+    -- FIXME: This shouldn't be desugared here because the names haven't been
+    -- resolved yet, so the signature of the coercion may clash.
     return $ Term.compose () origin
       [ Term.permissionCoercion permits () origin
       , Word () Operator.Postfix

--- a/lib/Kitten/Term.hs
+++ b/lib/Kitten/Term.hs
@@ -170,19 +170,23 @@ permissionCoercion permits x o = Coercion (AnyCoercion signature) x o
   signature = Signature.Quantified
     [ Parameter o "R" Kind.Stack
     , Parameter o "S" Kind.Stack
+    -- FIXME: This could clash with user-defined names because 'with' is
+    -- desugared too early, so we use the workaround of an invalid name.
+    , Parameter o "$P1" Kind.Permission
+    , Parameter o "$P2" Kind.Permission
     ]
     (Signature.Function
       [ Signature.StackFunction
         (Signature.Variable "R" o) []
         (Signature.Variable "S" o) []
-        (map permitName grants) o
+        (UnqualifiedName "$P1" : map permitName grants) o
       ]
       [ Signature.StackFunction
         (Signature.Variable "R" o) []
         (Signature.Variable "S" o) []
-        (map permitName revokes) o
+        (UnqualifiedName "$P1" : map permitName revokes) o
       ]
-      [] o) o
+      [UnqualifiedName "$P2"] o) o
   (grants, revokes) = partition permitted permits
 
 decompose :: Term a -> [Term a]
@@ -271,7 +275,9 @@ stripValue v = case v of
 
 instance Pretty (Term a) where
   pPrint term = case term of
-    Coercion{} -> Pretty.empty
+    Coercion IdentityCoercion _ _ -> Pretty.empty
+    Coercion (AnyCoercion signature) _ _
+      -> Pretty.hcat ["/* coerce ", pPrint signature, " */"]
     Compose _ a b -> pPrint a Pretty.$+$ pPrint b
     Generic name i body _ -> Pretty.hsep
       [ Pretty.angles $ Pretty.hcat [pPrint name, "/*", pPrint i, "*/"]


### PR DESCRIPTION
Permission elision generated too many implicit permission type variables.

This has a couple of hackish workarounds that need to be removed before it lands, because `with` terms are desugared too early, leading to potential name clashes.