### PR TITLE
Full read/show instances plus relational operators

### DIFF
--- a/common.ktn
+++ b/common.ktn
@@ -1317,6 +1317,68 @@ instance show (Float32 -> List<Char>):
 instance show (Float64 -> List<Char>):
   _::kitten::show_float64
 
+trait read<T> (List<Char> -> Optional<T>)
+
+instance read (List<Char> -> Optional<List<Char>>) { some }
+
+instance read (List<Char> -> Optional<Char>):
+  -> cs;
+  if (cs length = 1):
+    cs head
+  else:
+    none
+
+instance read (List<Char> -> Optional<Bool>):
+  -> cs;
+  if (cs = "true"): true some
+  elif (cs = "false"): false some
+  else: none
+
+vocab kitten {
+
+  intrinsic read_int8 (List<Char> -> Optional<Int8>)
+  intrinsic read_int16 (List<Char> -> Optional<Int16>)
+  intrinsic read_int32 (List<Char> -> Optional<Int32>)
+  intrinsic read_int64 (List<Char> -> Optional<Int64>)
+  intrinsic read_uint8 (List<Char> -> Optional<UInt8>)
+  intrinsic read_uint16 (List<Char> -> Optional<UInt16>)
+  intrinsic read_uint32 (List<Char> -> Optional<UInt32>)
+  intrinsic read_uint64 (List<Char> -> Optional<UInt64>)
+  intrinsic read_float32 (List<Char> -> Optional<Float32>)
+  intrinsic read_float64 (List<Char> -> Optional<Float64>)
+
+}
+
+instance read (List<Char> -> Optional<Int8>):
+  _::kitten::read_int8
+
+instance read (List<Char> -> Optional<Int16>):
+  _::kitten::read_int16
+
+instance read (List<Char> -> Optional<Int32>):
+  _::kitten::read_int32
+
+instance read (List<Char> -> Optional<Int64>):
+  _::kitten::read_int64
+
+instance read (List<Char> -> Optional<UInt8>):
+  _::kitten::read_uint8
+
+instance read (List<Char> -> Optional<UInt16>):
+  _::kitten::read_uint16
+
+instance read (List<Char> -> Optional<UInt32>):
+  _::kitten::read_uint32
+
+instance read (List<Char> -> Optional<UInt64>):
+  _::kitten::read_uint64
+
+instance read (List<Char> -> Optional<Float32>):
+  _::kitten::read_float32
+
+instance read (List<Char> -> Optional<Float64>):
+  _::kitten::read_float64
+
 define print<T> (T -> +IO) /* where (show<T>) */ :
   show _::kitten::print
 

--- a/common.ktn
+++ b/common.ktn
@@ -1232,6 +1232,8 @@ vocab kitten {
   intrinsic show_uint16 (UInt16 -> List<Char>)
   intrinsic show_uint32 (UInt32 -> List<Char>)
   intrinsic show_uint64 (UInt64 -> List<Char>)
+  intrinsic show_float32 (Float32 -> List<Char>)
+  intrinsic show_float64 (Float64 -> List<Char>)
 
 }
 
@@ -1258,6 +1260,12 @@ instance show (UInt32 -> List<Char>):
 
 instance show (UInt64 -> List<Char>):
   _::kitten::show_uint64
+
+instance show (Float32 -> List<Char>):
+  _::kitten::show_float32
+
+instance show (Float64 -> List<Char>):
+  _::kitten::show_float64
 
 define print<T> (T -> +IO) /* where (show<T>) */ :
   show _::kitten::print

--- a/common.ktn
+++ b/common.ktn
@@ -550,6 +550,34 @@ instance >= (Int64, Int64 -> Bool) { _::kitten::ge_int64 }
 instance = (Int64, Int64 -> Bool) { _::kitten::eq_int64 }
 instance <> (Int64, Int64 -> Bool) { _::kitten::ne_int64 }
 
+instance < (UInt8, UInt8 -> Bool) { _::kitten::lt_uint8 }
+instance > (UInt8, UInt8 -> Bool) { _::kitten::gt_uint8 }
+instance <= (UInt8, UInt8 -> Bool) { _::kitten::le_uint8 }
+instance >= (UInt8, UInt8 -> Bool) { _::kitten::ge_uint8 }
+instance = (UInt8, UInt8 -> Bool) { _::kitten::eq_uint8 }
+instance <> (UInt8, UInt8 -> Bool) { _::kitten::ne_uint8 }
+
+instance < (UInt16, UInt16 -> Bool) { _::kitten::lt_uint16 }
+instance > (UInt16, UInt16 -> Bool) { _::kitten::gt_uint16 }
+instance <= (UInt16, UInt16 -> Bool) { _::kitten::le_uint16 }
+instance >= (UInt16, UInt16 -> Bool) { _::kitten::ge_uint16 }
+instance = (UInt16, UInt16 -> Bool) { _::kitten::eq_uint16 }
+instance <> (UInt16, UInt16 -> Bool) { _::kitten::ne_uint16 }
+
+instance < (UInt32, UInt32 -> Bool) { _::kitten::lt_uint32 }
+instance > (UInt32, UInt32 -> Bool) { _::kitten::gt_uint32 }
+instance <= (UInt32, UInt32 -> Bool) { _::kitten::le_uint32 }
+instance >= (UInt32, UInt32 -> Bool) { _::kitten::ge_uint32 }
+instance = (UInt32, UInt32 -> Bool) { _::kitten::eq_uint32 }
+instance <> (UInt32, UInt32 -> Bool) { _::kitten::ne_uint32 }
+
+instance < (UInt64, UInt64 -> Bool) { _::kitten::lt_uint64 }
+instance > (UInt64, UInt64 -> Bool) { _::kitten::gt_uint64 }
+instance <= (UInt64, UInt64 -> Bool) { _::kitten::le_uint64 }
+instance >= (UInt64, UInt64 -> Bool) { _::kitten::ge_uint64 }
+instance = (UInt64, UInt64 -> Bool) { _::kitten::eq_uint64 }
+instance <> (UInt64, UInt64 -> Bool) { _::kitten::ne_uint64 }
+
 instance < (Char, Char -> Bool) { _::kitten::lt_char }
 instance > (Char, Char -> Bool) { _::kitten::gt_char }
 instance <= (Char, Char -> Bool) { _::kitten::le_char }
@@ -570,6 +598,10 @@ instance <= (Float64, Float64 -> Bool) { _::kitten::le_float64 }
 instance >= (Float64, Float64 -> Bool) { _::kitten::ge_float64 }
 instance = (Float64, Float64 -> Bool) { _::kitten::eq_float64 }
 instance <> (Float64, Float64 -> Bool) { _::kitten::ne_float64 }
+
+instance = (Bool, Bool -> Bool): if {} else {not}
+instance <> (Bool, Bool -> Bool) { (=) not }
+
 
 define abs<T> (T -> T):
   dup
@@ -979,9 +1011,7 @@ define elem<T> (T, List<T> -> Bool):
     false
 
 // TODO: Partial instances.
-trait == <T> (List<T>, List<T> -> Bool)
-
-instance == (List<Int32>, List<Int32> -> Bool):
+instance = (List<Int32>, List<Int32> -> Bool):
   -> xs, ys;
   if (xs length <> ys length):
     false
@@ -995,7 +1025,27 @@ instance == (List<Int32>, List<Int32> -> Bool):
         if (x <> y):
           false
         else:
-          xs_ == ys_
+          xs_ = ys_
+      case none:
+        true
+    case none:
+      true
+
+instance = (List<Char>, List<Char> -> Bool):
+  -> xs, ys;
+  if (xs length <> ys length):
+    false
+  else:
+    match (xs head_tail)
+    case some:
+      unpair -> x, xs_;
+      match (ys head_tail)
+      case some:
+        unpair -> y, ys_;
+        if (x <> y):
+          false
+        else:
+          xs_ = ys_
       case none:
         true
     case none:

--- a/common.ktn
+++ b/common.ktn
@@ -599,7 +599,11 @@ instance >= (Float64, Float64 -> Bool) { _::kitten::ge_float64 }
 instance = (Float64, Float64 -> Bool) { _::kitten::eq_float64 }
 instance <> (Float64, Float64 -> Bool) { _::kitten::ne_float64 }
 
-instance = (Bool, Bool -> Bool): if {} else {not}
+instance < (Bool, Bool -> Bool) { -> a, b; a not & b }
+instance > (Bool, Bool -> Bool) { -> a, b; a & b not }
+instance <= (Bool, Bool -> Bool) { (>) not }
+instance >= (Bool, Bool -> Bool) { (<) not }
+instance = (Bool, Bool -> Bool) { if {} else {not} }
 instance <> (Bool, Bool -> Bool) { (=) not }
 
 
@@ -1011,6 +1015,29 @@ define elem<T> (T, List<T> -> Bool):
     false
 
 // TODO: Partial instances.
+instance > (List<Int32>, List<Int32> -> Bool):
+  -> xs, ys;
+  match (xs head_tail)
+  case some:
+    unpair -> x, xs_;
+    match (ys head_tail)
+    case some:
+      unpair -> y, ys_;
+      if (x > y):
+        true
+      elif (x < y):
+        false
+      else:
+        xs_ > ys_
+    case none:
+      true
+  case none:
+    false
+
+instance < (List<Int32>, List<Int32> -> Bool) { swap (>) }
+instance <= (List<Int32>, List<Int32> -> Bool) { (>) not }
+instance >= (List<Int32>, List<Int32> -> Bool) { (<) not }
+
 instance = (List<Int32>, List<Int32> -> Bool):
   -> xs, ys;
   if (xs length <> ys length):
@@ -1031,6 +1058,31 @@ instance = (List<Int32>, List<Int32> -> Bool):
     case none:
       true
 
+instance <> (List<Int32>, List<Int32> -> Bool) { (=) not }
+
+instance > (List<Char>, List<Char> -> Bool):
+  -> xs, ys;
+  match (xs head_tail)
+  case some:
+    unpair -> x, xs_;
+    match (ys head_tail)
+    case some:
+      unpair -> y, ys_;
+      if (x > y):
+        true
+      elif (x < y):
+        false
+      else:
+        xs_ > ys_
+    case none:
+      true
+  case none:
+    false
+
+instance < (List<Char>, List<Char> -> Bool) { swap (>) }
+instance <= (List<Char>, List<Char> -> Bool) { (>) not }
+instance >= (List<Char>, List<Char> -> Bool) { (<) not }
+
 instance = (List<Char>, List<Char> -> Bool):
   -> xs, ys;
   if (xs length <> ys length):
@@ -1050,6 +1102,8 @@ instance = (List<Char>, List<Char> -> Bool):
         true
     case none:
       true
+
+instance <> (List<Char>, List<Char> -> Bool) { (=) not }
 
 define head<T> (List<T> -> Optional<T>):
   _::kitten::head

--- a/lib/Kitten/Interpret.hs
+++ b/lib/Kitten/Interpret.hs
@@ -10,6 +10,7 @@ Portability : GHC
 
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Kitten.Interpret
   ( Failure
@@ -438,6 +439,17 @@ interpret dictionary mName mainArgs stdin' stdout' _stderr' initialStack = do
       "show_float32" -> showFloat (show :: Float -> String)
       "show_float64" -> showFloat (show :: Double -> String)
 
+      "read_int8" -> readInteger (readIO :: String -> IO Int8) Signed8
+      "read_int16" -> readInteger (readIO :: String -> IO Int16) Signed16
+      "read_int32" -> readInteger (readIO :: String -> IO Int32) Signed32
+      "read_int64" -> readInteger (readIO :: String -> IO Int64) Signed64
+      "read_uint8" -> readInteger (readIO :: String -> IO Word8) Unsigned8
+      "read_uint16" -> readInteger (readIO :: String -> IO Word16) Unsigned16
+      "read_uint32" -> readInteger (readIO :: String -> IO Word32) Unsigned32
+      "read_uint64" -> readInteger (readIO :: String -> IO Word64) Unsigned64
+      "read_float32" -> readFloat (readIO :: String -> IO Float) Float32
+      "read_float64" -> readFloat (readIO :: String -> IO Double) Float64
+
       "empty" -> do
         Array xs ::: r <- readIORef stackRef
         writeIORef stackRef r
@@ -829,6 +841,30 @@ interpret dictionary mName mainArgs stdin' stdout' _stderr' initialStack = do
         Float x _ ::: r <- readIORef stackRef
         writeIORef stackRef $ Array
           (Vector.fromList $ map Character $ f $ realToFrac x) ::: r
+
+      readInteger :: Integral a => (String -> IO a) -> IntegerBits -> IO ()
+      readInteger f b = do
+        Array cs ::: r <- readIORef stackRef
+        do
+          result <- f $ map (\ (Character c) -> c) $ Vector.toList cs
+          writeIORef stackRef $ Integer (fromIntegral result) b ::: r
+          -- FIXME: Use right args.
+          word callStack (Qualified Vocabulary.global "some") []
+          `catch` \ (_ :: IOError) -> do
+            writeIORef stackRef r
+            word callStack (Qualified Vocabulary.global "none") []
+
+      readFloat :: Real a => (String -> IO a) -> FloatBits -> IO ()
+      readFloat f b = do
+        Array cs ::: r <- readIORef stackRef
+        do
+          result <- f $ map (\ (Character c) -> c) $ Vector.toList cs
+          writeIORef stackRef $ Float (realToFrac result) b ::: r
+          -- FIXME: Use right args.
+          word callStack (Qualified Vocabulary.global "some") []
+          `catch` \ (_ :: IOError) -> do
+            writeIORef stackRef r
+            word callStack (Qualified Vocabulary.global "none") []
 
       catchDivideByZero :: IO a -> IO a
       catchDivideByZero action = action `catch` \ e -> case e of

--- a/lib/Kitten/Interpret.hs
+++ b/lib/Kitten/Interpret.hs
@@ -435,6 +435,8 @@ interpret dictionary mName mainArgs stdin' stdout' _stderr' initialStack = do
       "show_uint16" -> showInteger (show :: Word16 -> String)
       "show_uint32" -> showInteger (show :: Word32 -> String)
       "show_uint64" -> showInteger (show :: Word64 -> String)
+      "show_float32" -> showFloat (show :: Float -> String)
+      "show_float64" -> showFloat (show :: Double -> String)
 
       "empty" -> do
         Array xs ::: r <- readIORef stackRef
@@ -821,6 +823,12 @@ interpret dictionary mName mainArgs stdin' stdout' _stderr' initialStack = do
         Integer x _ ::: r <- readIORef stackRef
         writeIORef stackRef $ Array
           (Vector.fromList $ map Character $ f (fromIntegral x)) ::: r
+
+      showFloat :: Fractional a => (a -> String) -> IO ()
+      showFloat f = do
+        Float x _ ::: r <- readIORef stackRef
+        writeIORef stackRef $ Array
+          (Vector.fromList $ map Character $ f $ realToFrac x) ::: r
 
       catchDivideByZero :: IO a -> IO a
       catchDivideByZero action = action `catch` \ e -> case e of


### PR DESCRIPTION
Added missing relational operators e.g. unsigned comparisons and = <> for Booleans (~ looks a bit redundant for booleans since it's the same as <> really, but it's still a useful operator for other stuff such as bitwise).  Further extended this to make Booleans ordered by false < true and created lexicographical orderings and comparisons for many types of lists (done away with the == form of equals since it's a bit useless, preventing basic usages of comparisons for example with the elem function on a list of strings).

Added show instances for floating point values, and implemented polymorphic 'read' trait for parsing back in all the basic types supported by show (so you should be able to invert a show by doing a read and from_some).