### PR TITLE
Update ebook URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Kitten is distributed under the terms of the [MIT license][license]. Contributor
 [code of conduct]: https://github.com/evincarofautumn/kitten/blob/master/CODE_OF_CONDUCT.md
 [wcpm]: http://evincarofautumn.blogspot.com/2012/02/why-concatenative-programming-matters.html
 [cpim]: https://www.youtube.com/watch?v=_IgqJr8jG8M
-[ebook]: https://www.gitbook.com/book/evincarofautumn/programming-with-kitten
+[ebook]: https://evincarofautumn.gitbooks.io/programming-with-kitten/
 [initial release]: https://github.com/evincarofautumn/kitten/projects/1
 [contributing]: https://github.com/evincarofautumn/kitten/blob/master/CONTRIBUTING.md
 [gitter]: https://gitter.im/kittenlang/Lobby


### PR DESCRIPTION
This pull request updates the ebook URL in the README.

The [old URL](https://www.gitbook.com/book/evincarofautumn/programming-with-kitten) redirects to legacy.gitbook.com. Instead of the ebook, a user who's not logged in will see a message saying:

```
Please log in to preview this content
You can still access this book's content using the Read button.
```

The [new URL](https://evincarofautumn.gitbooks.io/programming-with-kitten/) points directly to the ebook.